### PR TITLE
Fix Progressbar non-daemon Timer threads blocking interpreter shutdown

### DIFF
--- a/src/larakit/progressbar.py
+++ b/src/larakit/progressbar.py
@@ -74,10 +74,14 @@ class Progressbar:
         self._progress: float = 0.0
         self._background_thread: Optional[threading.Timer] = None
         self._previous_update_length: int = 0
+        self._stopped: bool = False
 
     def _timer_handle(self) -> None:
         self._update()
+        if self._stopped:
+            return
         self._background_thread = threading.Timer(self._refresh_timeout, self._timer_handle)
+        self._background_thread.daemon = True
         self._background_thread.start()
 
     def _render(self, elapsed_time: float, eta: float, message: str = None) -> str:
@@ -145,11 +149,13 @@ class Progressbar:
         self._progress = min(1., max(0., progress))
 
     def cancel(self) -> None:
+        self._stopped = True
         if self._background_thread is not None:
             self._background_thread.cancel()
         sys.stdout.write(self._esc_show_cursor)
 
     def complete(self) -> None:
+        self._stopped = True
         if self._background_thread is not None:
             self._background_thread.cancel()
         self._progress = 1.0
@@ -158,6 +164,7 @@ class Progressbar:
         sys.stdout.write(self._esc_show_cursor)
 
     def abort(self, error: str = None) -> None:
+        self._stopped = True
         if self._background_thread is not None:
             self._background_thread.cancel()
         self._update(message=None if error is None else f' ERROR: {error}')


### PR DESCRIPTION
## Summary

- `Progressbar._timer_handle` was scheduling a chained `threading.Timer` that was **non-daemon**, so `threading._shutdown()` had to join it on interpreter exit.
- Because `Timer.cancel()` is a no-op once the timer has fired, a race with `cancel()` / `complete()` / `abort()` could let `_timer_handle` spawn a fresh Timer **after** the terminator returned, producing an endless chain of non-daemon Timer threads. Any process using `Progressbar` could hang forever on `sys.exit()`.
- Discovered while running `larabench runall`: after `engine.stop()` the script was stuck in `threading._shutdown` at `lock.acquire()`; SIGINT was the only way out.

## Fix

- Added an `_stopped` flag. `_timer_handle` now bails after the final `_update()` if it's set, so no new Timer is scheduled once a terminator has run.
- `cancel()`, `complete()`, and `abort()` all set `_stopped = True` before cancelling the current timer.
- Belt-and-suspenders: new Timer threads are marked `daemon = True`, so even if some future change reopens the race, the interpreter can still shut down.

## Test plan

- [x] Manual repro: a script that calls `start()` -> `complete()` -> `sys.exit(0)` previously hung; with this change it exits cleanly with status 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
