### PR TITLE
Add `properties` to `MultilingualCorpus`

### DIFF
--- a/src/larakit/corpus/_base.py
+++ b/src/larakit/corpus/_base.py
@@ -213,3 +213,8 @@ class MultilingualCorpus(ABC):
     @abstractmethod
     def writer(self) -> TUWriter:
         pass
+
+    @property
+    @abstractmethod
+    def properties(self) -> Optional[Properties]:
+        pass

--- a/src/larakit/corpus/_parallel.py
+++ b/src/larakit/corpus/_parallel.py
@@ -2,7 +2,7 @@ import os
 from typing import Set, Optional, TextIO, Generator
 
 from larakit import LanguageDirection
-from larakit.corpus._base import MultilingualCorpus, TUReader, TranslationUnit, TUWriter
+from larakit.corpus._base import MultilingualCorpus, TUReader, TranslationUnit, TUWriter, Properties
 
 
 class ParallelCorpusReader(TUReader):
@@ -83,3 +83,6 @@ class ParallelCorpus(MultilingualCorpus):
 
     def writer(self) -> ParallelCorpusWriter:
         return ParallelCorpusWriter(self._language, self._source, self._target)
+
+    def properties(self) -> Optional[Properties]:
+        return None

--- a/src/larakit/corpus/_parallel.py
+++ b/src/larakit/corpus/_parallel.py
@@ -84,5 +84,6 @@ class ParallelCorpus(MultilingualCorpus):
     def writer(self) -> ParallelCorpusWriter:
         return ParallelCorpusWriter(self._language, self._source, self._target)
 
+    @property
     def properties(self) -> Optional[Properties]:
         return None


### PR DESCRIPTION
Adds `properties` as an abstract property on `MultilingualCorpus` so all corpus types expose a consistent read interface. `ParallelCorpus` implements it as None since the parallel text format has no corpus-level metadata, while `JTMCorpus` and `TMXCorpus` already satisfy the contract.