### PR TITLE
Add `Language` ordering and `LanguageDirection` string utilities

### DIFF
--- a/src/larakit/_lang.py
+++ b/src/larakit/_lang.py
@@ -355,7 +355,9 @@ class Language:
 
         return True
 
-    def __eq__(self, other: 'Language') -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Language):
+            return NotImplemented
         return self.tag == other.tag
 
     def __lt__(self, other: 'Language') -> bool:
@@ -405,6 +407,8 @@ class LanguageDirection:
 
     @classmethod
     def from_string(cls, string: str) -> 'LanguageDirection':
+        if string is None:
+            raise ValueError("Input string must not be None")
         parts: List[str] = string.split('__')
         if len(parts) != 2:
             raise ValueError(f"Language direction string must contain two parts, got {len(parts)} in '{string}'")

--- a/src/larakit/_lang.py
+++ b/src/larakit/_lang.py
@@ -422,6 +422,9 @@ class LanguageDirection:
             return self
         return LanguageDirection(source=self.source.as_language_only(), target=self.target.as_language_only())
 
+    def to_tuple(self) -> Tuple[str, str]:
+        return self.to_json()
+
     def to_json(self) -> Tuple[str, str]:
         return self.source.tag, self.target.tag
 

--- a/src/larakit/_lang.py
+++ b/src/larakit/_lang.py
@@ -395,7 +395,7 @@ class LanguageDirection:
 
     @property
     def ordered(self) -> 'LanguageDirection':
-        return self if self.source < self.target else self.reversed
+        return self.reversed if self.target < self.source else self
 
     @classmethod
     def from_tuple(cls, language: Tuple[str, str]) -> 'LanguageDirection':

--- a/src/larakit/_lang.py
+++ b/src/larakit/_lang.py
@@ -395,7 +395,7 @@ class LanguageDirection:
 
     @property
     def ordered(self) -> 'LanguageDirection':
-        return self.reversed if self.target < self.source else self
+        return self if self.source < self.target else self.reversed
 
     @classmethod
     def from_tuple(cls, language: Tuple[str, str]) -> 'LanguageDirection':

--- a/src/larakit/_lang.py
+++ b/src/larakit/_lang.py
@@ -358,6 +358,11 @@ class Language:
     def __eq__(self, other: 'Language') -> bool:
         return self.tag == other.tag
 
+    def __lt__(self, other: 'Language') -> bool:
+        if not isinstance(other, Language):
+            return NotImplemented
+        return self.tag < other.tag
+
     def __hash__(self) -> int:
         return hash(self.tag)
 
@@ -388,15 +393,34 @@ class LanguageDirection:
             self._reversed = LanguageDirection(source=self.target, target=self.source)
         return self._reversed
 
+    @property
+    def ordered(self) -> 'LanguageDirection':
+        return self.reversed if self.target < self.source else self
+
     @classmethod
     def from_tuple(cls, language: Tuple[str, str]) -> 'LanguageDirection':
         if len(language) != 2:
             raise ValueError(f"Language tuple must contain two elements, got {len(language)}")
         return cls(source=Language.from_string(language[0]), target=Language.from_string(language[1]))
 
+    @classmethod
+    def from_string(cls, string: str) -> 'LanguageDirection':
+        parts: List[str] = string.split('__')
+        if len(parts) != 2:
+            raise ValueError(f"Language direction string must contain two parts, got {len(parts)} in '{string}'")
+        return cls(source=Language.from_string(parts[0]), target=Language.from_string(parts[1]))
+
     def is_equal_or_more_generic_than(self, other: 'LanguageDirection') -> bool:
         return (self.source.is_equal_or_more_generic_than(other.source) and
                 self.target.is_equal_or_more_generic_than(other.target))
+
+    def is_language_only(self) -> bool:
+        return self.source.is_language_only() and self.target.is_language_only()
+
+    def as_language_only(self) -> 'LanguageDirection':
+        if self.is_language_only():
+            return self
+        return LanguageDirection(source=self.source.as_language_only(), target=self.target.as_language_only())
 
     def to_json(self) -> Tuple[str, str]:
         return self.source.tag, self.target.tag
@@ -408,6 +432,11 @@ class LanguageDirection:
             return False
         return self.source == other.source and self.target == other.target
 
+    def __lt__(self, other: 'LanguageDirection') -> bool:
+        if not isinstance(other, LanguageDirection):
+            return NotImplemented
+        return (self.source, self.target) < (other.source, other.target)
+
     def __hash__(self) -> int:
         return hash((self.source, self.target))
 
@@ -415,4 +444,4 @@ class LanguageDirection:
         return self.__str__()
 
     def __str__(self) -> str:
-        return f"{self.source}\u2192{self.target}"
+        return f"{self.source}__{self.target}"

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -9,11 +9,6 @@ class TestLanguage(unittest.TestCase):
         self.assertLess(Language.from_string("en"), Language.from_string("en-US"))
         self.assertFalse(Language.from_string("it") < Language.from_string("it"))
 
-    def test_lt_non_language_operand(self):
-        self.assertEqual(Language.from_string("en").__lt__("en"), NotImplemented)
-        with self.assertRaises(TypeError):
-            _ = Language.from_string("en") < "en"
-
     def test_sorted(self):
         languages = [Language.from_string(s) for s in ("it", "en-US", "de", "zh-Hant", "en")]
         sorted_tags = [language.tag for language in sorted(languages)]
@@ -25,12 +20,6 @@ class TestLanguageDirection(unittest.TestCase):
         self.assertLess(LanguageDirection.from_string("de__en"), LanguageDirection.from_string("en__de"))
         self.assertLess(LanguageDirection.from_string("en__de"), LanguageDirection.from_string("en__it"))
         self.assertFalse(LanguageDirection.from_string("en__it") < LanguageDirection.from_string("en__it"))
-
-    def test_lt_non_direction_operand(self):
-        direction = LanguageDirection.from_string("en__it")
-        self.assertEqual(direction.__lt__("en__it"), NotImplemented)
-        with self.assertRaises(TypeError):
-            _ = direction < "en__it"
 
     def test_sorted(self):
         directions = [LanguageDirection.from_string(s) for s in ("it__en", "en__it", "en__de", "de__en")]

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -4,6 +4,10 @@ from larakit import Language, LanguageDirection
 
 
 class TestLanguage(unittest.TestCase):
+    def test_eq_non_language(self):
+        self.assertNotEqual(Language.from_string("en"), "en")
+        self.assertNotEqual(Language.from_string("en"), None)
+
     def test_lt(self):
         self.assertLess(Language.from_string("de"), Language.from_string("en"))
         self.assertLess(Language.from_string("en"), Language.from_string("en-US"))
@@ -55,7 +59,7 @@ class TestLanguageDirection(unittest.TestCase):
             self.assertEqual(LanguageDirection.from_string(str(direction)), direction)
 
     def test_from_string_invalid(self):
-        for string in ("en", "a__b__c", "__it", "en__", "__", ""):
+        for string in ("en", "a__b__c", "__it", "en__", "__", "", None):
             with self.assertRaises(ValueError, msg=f"string: '{string}'"):
                 LanguageDirection.from_string(string)
 

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -1,0 +1,88 @@
+import unittest
+
+from larakit import Language, LanguageDirection
+
+
+class TestLanguage(unittest.TestCase):
+    def test_lt(self):
+        self.assertLess(Language.from_string("de"), Language.from_string("en"))
+        self.assertLess(Language.from_string("en"), Language.from_string("en-US"))
+        self.assertFalse(Language.from_string("it") < Language.from_string("it"))
+
+    def test_lt_non_language_operand(self):
+        self.assertEqual(Language.from_string("en").__lt__("en"), NotImplemented)
+        with self.assertRaises(TypeError):
+            _ = Language.from_string("en") < "en"
+
+    def test_sorted(self):
+        languages = [Language.from_string(s) for s in ("it", "en-US", "de", "zh-Hant", "en")]
+        sorted_tags = [language.tag for language in sorted(languages)]
+        self.assertEqual(sorted_tags, ["de", "en", "en-US", "it", "zh-Hant"])
+
+
+class TestLanguageDirection(unittest.TestCase):
+    def test_lt(self):
+        self.assertLess(LanguageDirection.from_string("de__en"), LanguageDirection.from_string("en__de"))
+        self.assertLess(LanguageDirection.from_string("en__de"), LanguageDirection.from_string("en__it"))
+        self.assertFalse(LanguageDirection.from_string("en__it") < LanguageDirection.from_string("en__it"))
+
+    def test_lt_non_direction_operand(self):
+        direction = LanguageDirection.from_string("en__it")
+        self.assertEqual(direction.__lt__("en__it"), NotImplemented)
+        with self.assertRaises(TypeError):
+            _ = direction < "en__it"
+
+    def test_sorted(self):
+        directions = [LanguageDirection.from_string(s) for s in ("it__en", "en__it", "en__de", "de__en")]
+        sorted_strings = [str(direction) for direction in sorted(directions)]
+        self.assertEqual(sorted_strings, ["de__en", "en__de", "en__it", "it__en"])
+
+    def test_ordered(self):
+        self.assertEqual(str(LanguageDirection.from_string("en__de").ordered), "de__en")
+        self.assertEqual(str(LanguageDirection.from_string("zh-Hant__en").ordered), "en__zh-Hant")
+        self.assertEqual(str(LanguageDirection.from_string("it-IT__en-US").ordered), "en-US__it-IT")
+
+    def test_ordered_returns_self_when_ordered(self):
+        direction = LanguageDirection.from_string("de__en")
+        self.assertIs(direction.ordered, direction)
+
+    def test_str(self):
+        self.assertEqual(str(LanguageDirection.from_tuple(("en-US", "it-IT"))), "en-US__it-IT")
+        self.assertEqual(str(LanguageDirection.from_tuple(("zh-Hant", "en"))), "zh-Hant__en")
+        self.assertEqual(str(LanguageDirection.from_tuple(("en", "it"))), "en__it")
+
+    def test_from_string(self):
+        direction = LanguageDirection.from_string("en-US__it")
+        self.assertEqual(direction.source.tag, "en-US")
+        self.assertEqual(direction.target.tag, "it")
+
+        direction = LanguageDirection.from_string("zh-Hant__en")
+        self.assertEqual(direction.source.script, "Hant")
+        self.assertEqual(direction.target.tag, "en")
+
+    def test_from_string_round_trip(self):
+        for pair in (("en", "it"), ("en-US", "it-IT"), ("zh-Hant", "en")):
+            direction = LanguageDirection.from_tuple(pair)
+            self.assertEqual(LanguageDirection.from_string(str(direction)), direction)
+
+    def test_from_string_invalid(self):
+        for string in ("en", "a__b__c", "__it", "en__", "__", ""):
+            with self.assertRaises(ValueError, msg=f"string: '{string}'"):
+                LanguageDirection.from_string(string)
+
+    def test_is_language_only(self):
+        self.assertTrue(LanguageDirection.from_string("en__it").is_language_only())
+        self.assertFalse(LanguageDirection.from_string("en-US__it").is_language_only())
+        self.assertFalse(LanguageDirection.from_string("en__it-IT").is_language_only())
+        self.assertFalse(LanguageDirection.from_string("zh-Hant__en").is_language_only())
+
+    def test_as_language_only(self):
+        direction = LanguageDirection.from_string("en-US__it-IT")
+        self.assertEqual(direction.as_language_only(), LanguageDirection.from_string("en__it"))
+
+        direction = LanguageDirection.from_string("zh-Hant__en")
+        self.assertEqual(direction.as_language_only(), LanguageDirection.from_string("zh__en"))
+
+    def test_as_language_only_returns_self_when_language_only(self):
+        direction = LanguageDirection.from_string("en__it")
+        self.assertIs(direction.as_language_only(), direction)


### PR DESCRIPTION
Utility additions to `Language` and `LanguageDirection`.

> **Behavior change:** `str()`/`repr()` of `LanguageDirection` now render `'en__it'` instead of `'en→it'`. `to_json()` unchanged.

- `Language.__lt__` / `LanguageDirection.__lt__` — both types sort natively (by tag, by `(source, target)`)
- `LanguageDirection.from_string("en-US__it")` — inverse of `str()`; `ValueError` on malformed input
- `LanguageDirection.ordered` — direction with sides sorted: `it__en` → `en__it`, `en__it` → `en__it` (self)
- `LanguageDirection.is_language_only()` / `as_language_only()` — mirror the `Language` methods