### PR TITLE
Deprecate `LanguageDirection.reversed`/`ordered` for `swapped()`/`sorted()`

### DIFF
--- a/src/larakit/_lang.py
+++ b/src/larakit/_lang.py
@@ -380,7 +380,7 @@ class LanguageDirection:
     def __init__(self, source: Language, target: Language):
         self._source: Language = source
         self._target: Language = target
-        self._reversed: Optional['LanguageDirection'] = None
+        self._swapped: Optional['LanguageDirection'] = None
 
     @property
     def source(self) -> Language:
@@ -401,9 +401,10 @@ class LanguageDirection:
         return self.sorted()
 
     def swapped(self) -> 'LanguageDirection':
-        if self._reversed is None:
-            self._reversed = LanguageDirection(source=self.target, target=self.source)
-        return self._reversed
+        if self._swapped is None:
+            self._swapped = LanguageDirection(source=self.target, target=self.source)
+            self._swapped._swapped = self
+        return self._swapped
 
     def sorted(self) -> 'LanguageDirection':
         return self.swapped() if self.target < self.source else self

--- a/src/larakit/_lang.py
+++ b/src/larakit/_lang.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional, List, Tuple, Dict
 
 
@@ -390,14 +391,22 @@ class LanguageDirection:
         return self._target
 
     @property
-    def reversed(self):
+    def reversed(self) -> 'LanguageDirection':
+        warnings.warn("'reversed' is deprecated; use 'swapped()' instead.", DeprecationWarning, stacklevel=2)
+        return self.swapped()
+
+    @property
+    def ordered(self) -> 'LanguageDirection':
+        warnings.warn("'ordered' is deprecated; use 'sorted()' instead.", DeprecationWarning, stacklevel=2)
+        return self.sorted()
+
+    def swapped(self) -> 'LanguageDirection':
         if self._reversed is None:
             self._reversed = LanguageDirection(source=self.target, target=self.source)
         return self._reversed
 
-    @property
-    def ordered(self) -> 'LanguageDirection':
-        return self.reversed if self.target < self.source else self
+    def sorted(self) -> 'LanguageDirection':
+        return self.swapped() if self.target < self.source else self
 
     @classmethod
     def from_tuple(cls, language: Tuple[str, str]) -> 'LanguageDirection':

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -30,14 +30,18 @@ class TestLanguageDirection(unittest.TestCase):
         sorted_strings = [str(direction) for direction in sorted(directions)]
         self.assertEqual(sorted_strings, ["de__en", "en__de", "en__it", "it__en"])
 
-    def test_ordered(self):
-        self.assertEqual(str(LanguageDirection.from_string("en__de").ordered), "de__en")
-        self.assertEqual(str(LanguageDirection.from_string("zh-Hant__en").ordered), "en__zh-Hant")
-        self.assertEqual(str(LanguageDirection.from_string("it-IT__en-US").ordered), "en-US__it-IT")
+    def test_swapped(self):
+        self.assertEqual(str(LanguageDirection.from_string("en__de").swapped()), "de__en")
+        self.assertEqual(str(LanguageDirection.from_string("zh-Hant__en").swapped()), "en__zh-Hant")
 
-    def test_ordered_returns_self_when_ordered(self):
+    def test_sorted_orders_by_language(self):
+        self.assertEqual(str(LanguageDirection.from_string("en__de").sorted()), "de__en")
+        self.assertEqual(str(LanguageDirection.from_string("zh-Hant__en").sorted()), "en__zh-Hant")
+        self.assertEqual(str(LanguageDirection.from_string("it-IT__en-US").sorted()), "en-US__it-IT")
+
+    def test_sorted_returns_self_when_already_sorted(self):
         direction = LanguageDirection.from_string("de__en")
-        self.assertIs(direction.ordered, direction)
+        self.assertIs(direction.sorted(), direction)
 
     def test_str(self):
         self.assertEqual(str(LanguageDirection.from_tuple(("en-US", "it-IT"))), "en-US__it-IT")


### PR DESCRIPTION
The `reversed` and `ordered` properties on `LanguageDirection` had imprecise names. This converts them into standard methods:

- `reversed` → `swapped()` — swaps source/target
- `ordered` → `sorted()` — orders the pair by language

The old properties remain but emit a `DeprecationWarning` and delegate to the new methods, so existing callers keep working.