### PR TITLE
Deprecate `LanguageDirection.from_tuple`; accept `str` in constructor

### DIFF
--- a/src/larakit/_lang.py
+++ b/src/larakit/_lang.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, List, Tuple, Dict
+from typing import Optional, List, Tuple, Dict, Union
 
 
 class Language:
@@ -377,9 +377,9 @@ class Language:
 
 
 class LanguageDirection:
-    def __init__(self, source: Language, target: Language):
-        self._source: Language = source
-        self._target: Language = target
+    def __init__(self, source: Union[str, Language], target: Union[str, Language]):
+        self._source: Language = Language.from_string(source) if isinstance(source, str) else source
+        self._target: Language = Language.from_string(target) if isinstance(target, str) else target
         self._swapped: Optional['LanguageDirection'] = None
 
     @property
@@ -410,9 +410,11 @@ class LanguageDirection:
 
     @classmethod
     def from_tuple(cls, language: Tuple[str, str]) -> 'LanguageDirection':
+        warnings.warn("'from_tuple' is deprecated; pass source and target to the constructor instead.",
+                      DeprecationWarning, stacklevel=2)
         if len(language) != 2:
             raise ValueError(f"Language tuple must contain two elements, got {len(language)}")
-        return cls(source=Language.from_string(language[0]), target=Language.from_string(language[1]))
+        return cls(*language)
 
     @classmethod
     def from_string(cls, string: str) -> 'LanguageDirection':

--- a/src/larakit/corpus/_base.py
+++ b/src/larakit/corpus/_base.py
@@ -104,7 +104,7 @@ class TranslationUnit:
     @classmethod
     def from_json(cls, json_data: Dict[str, Union[str, List[str], Tuple[str, str]]]) -> 'TranslationUnit':
         properties_data: Optional[Dict] = json_data.get("properties", None)
-        return cls(language=LanguageDirection.from_tuple(json_data['language']), sentence=json_data["sentence"],
+        return cls(language=LanguageDirection(*json_data['language']), sentence=json_data["sentence"],
                    translation=json_data["translation"], tuid=json_data.get("tuid", None),
                    creation_date=json_data.get("creationDate", None), change_date=json_data.get("changeDate", None),
                    properties=Properties.from_json(properties_data) if properties_data is not None else None)

--- a/src/larakit/corpus/_jtm.py
+++ b/src/larakit/corpus/_jtm.py
@@ -74,7 +74,7 @@ class JTMCorpus(MultilingualCorpus):
 
         @classmethod
         def from_json(cls, data: Dict[str, Any]) -> 'JTMCorpus.Footer':
-            counter = Counter({LanguageDirection.from_tuple(lang_tuple): lang_count
+            counter = Counter({LanguageDirection(*lang_tuple): lang_count
                                for lang_tuple, lang_count in data.get("counter", [])})
 
             properties_data: Optional[Dict] = data.get("properties", None)

--- a/src/larakit/corpus/_parallel.py
+++ b/src/larakit/corpus/_parallel.py
@@ -68,7 +68,7 @@ class ParallelCorpus(MultilingualCorpus):
         source_parts = os.path.splitext(os.path.basename(source))
         target_parts = os.path.splitext(os.path.basename(target))
         self._name = source_parts[0]
-        self._language: LanguageDirection = LanguageDirection.from_tuple((source_parts[1][1:], target_parts[1][1:]))
+        self._language: LanguageDirection = LanguageDirection(source_parts[1][1:], target_parts[1][1:])
         self._size: Optional[int] = None
 
     @property

--- a/src/larakit/corpus/_tmx.py
+++ b/src/larakit/corpus/_tmx.py
@@ -119,7 +119,7 @@ class TMXReader(TUReader):
             if not all([source_tuv.lang, source_tuv.text, target_tuv.lang, target_tuv.text]):
                 continue
 
-            lang_dir = LanguageDirection.from_tuple((source_tuv.lang, target_tuv.lang))
+            lang_dir = LanguageDirection(source_tuv.lang, target_tuv.lang)
             yield TranslationUnit(
                 language=lang_dir, sentence=source_tuv.text, translation=target_tuv.text,
                 tuid=tu_element.attrib.get("tuid"),

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -44,9 +44,19 @@ class TestLanguageDirection(unittest.TestCase):
         self.assertIs(direction.sorted(), direction)
 
     def test_str(self):
-        self.assertEqual(str(LanguageDirection.from_tuple(("en-US", "it-IT"))), "en-US__it-IT")
-        self.assertEqual(str(LanguageDirection.from_tuple(("zh-Hant", "en"))), "zh-Hant__en")
-        self.assertEqual(str(LanguageDirection.from_tuple(("en", "it"))), "en__it")
+        self.assertEqual(str(LanguageDirection("en-US", "it-IT")), "en-US__it-IT")
+        self.assertEqual(str(LanguageDirection("zh-Hant", "en")), "zh-Hant__en")
+        self.assertEqual(str(LanguageDirection("en", "it")), "en__it")
+
+    def test_constructor_accepts_str(self):
+        direction = LanguageDirection("en-US", "it")
+        self.assertEqual(direction.source.tag, "en-US")
+        self.assertEqual(direction.target.tag, "it")
+
+    def test_constructor_accepts_language(self):
+        direction = LanguageDirection(Language.from_string("en-US"), Language.from_string("it"))
+        self.assertEqual(direction.source.tag, "en-US")
+        self.assertEqual(direction.target.tag, "it")
 
     def test_from_string(self):
         direction = LanguageDirection.from_string("en-US__it")
@@ -59,7 +69,7 @@ class TestLanguageDirection(unittest.TestCase):
 
     def test_from_string_round_trip(self):
         for pair in (("en", "it"), ("en-US", "it-IT"), ("zh-Hant", "en")):
-            direction = LanguageDirection.from_tuple(pair)
+            direction = LanguageDirection(*pair)
             self.assertEqual(LanguageDirection.from_string(str(direction)), direction)
 
     def test_from_string_invalid(self):


### PR DESCRIPTION
## Context

`LanguageDirection.from_tuple((src, tgt))` forced callers to wrap two strings in a tuple, and the constructor only accepted `Language` objects. This mirrors the prior `reversed`/`ordered` → `swapped()`/`sorted()` deprecation (#45).

## Changes

- **Constructor** accepts `Union[str, Language]` for both `source` and `target`, converting `str` via `Language.from_string`.
- **`from_tuple`** deprecated — emits `DeprecationWarning`, delegates to the constructor (still works).
- **Internal callers** (`_tmx`, `_parallel`, `_jtm`, `_base`) switched to the constructor directly, avoiding the warning.
- **Tests** updated to use the constructor; added str + `Language` constructor tests.